### PR TITLE
Update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,6 @@
 *.lib
 
 # Executables
-*.exe
 *.out
 *.app
 


### PR DESCRIPTION
.exe files are no longer excluded when pushing. An executable is needed for AI to work